### PR TITLE
Fix Link Button

### DIFF
--- a/slack/web/classes/elements.py
+++ b/slack/web/classes/elements.py
@@ -152,7 +152,12 @@ class LinkButtonElement(ButtonElement):
             style: "primary" or "danger" to add specific styling to this button.
         """
         random_id = "".join(random.choice(string.ascii_uppercase) for _ in range(16))
-        super().__init__(text=text, action_id=random_id, value="", style=style)
+        super().__init__(
+            text=text, 
+            action_id=random_id, 
+            value=random_id, 
+            style=style
+        )
         self.url = url
 
     @JsonValidator(f"url attribute cannot exceed {url_max_length} characters")

--- a/tests/web/classes/test_elements.py
+++ b/tests/web/classes/test_elements.py
@@ -84,7 +84,7 @@ class LinkButtonElementTests(unittest.TestCase):
                 "text": {"emoji": True, "text": "button text", "type": "plain_text"},
                 "url": "http://google.com",
                 "type": "button",
-                "value": "",
+                "value": button.value,
                 "action_id": button.action_id,
             },
         )


### PR DESCRIPTION
Button requires a string for value. To fix this use the same random_id as the action id

###  Summary

Fixed the minor bug in #546 where there needs to be a string value for LinkButtonElement

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).